### PR TITLE
WRP-24433: Upgraded minimatch dependency to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact eslint plugin:
 
 ## [unreleased]
 
-* Updated the minimum version of Node to `14.17.0`.
+* Updated `minimatch` version to `^9.0.3` and the minimum version of Node to `14.17.0`.
 
 ## [1.0.4] - (July 4, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 The following is a curated list of changes in the Enact eslint plugin:
 
+## [unreleased]
+
+* Updated the minimum version of Node to `14.17.0`.
+
 ## [1.0.4] - (July 4, 2023)
 
 * Updated dependencies.

--- a/lib/rules/no-module-exports-import.js
+++ b/lib/rules/no-module-exports-import.js
@@ -7,7 +7,7 @@
  * remove entrypoint detection by Jason Robitaille
  */
 
-var minimatch = require('minimatch');
+var {minimatch} = require('minimatch');
 var path = require('path');
 
 module.exports = {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "doctrine": "^3.0.0",
         "jsx-ast-utils": "^3.3.3",
-        "minimatch": "^6.1.6"
+        "minimatch": "^9.0.3"
       },
       "devDependencies": {
         "eslint": "^8.42.0",
@@ -1620,14 +1620,14 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3568,9 +3568,9 @@
       }
     },
     "minimatch": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-6.2.0.tgz",
-      "integrity": "sha512-sauLxniAmvnhhRjFwPNnJKaPFYyddAgbYdeUpHULtCT/GhzdCx/MDNy+Y40lBxTQUrMzDE8e0S43Z5uqfO0REg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
       "requires": {
         "brace-expansion": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "dependencies": {
     "doctrine": "^3.0.0",
     "jsx-ast-utils": "^3.3.3",
-    "minimatch": "^6.1.6"
+    "minimatch": "^9.0.3"
   },
   "peerDependencies": {
     "eslint": ">=8.0.0"
   },
   "engines": {
-    "node": ">=10.16.0"
+    "node": ">=14.17.0"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
Upgraded minimatch dependency to the latest version

### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
The minimum node version required by minimatch is 14.17.
Changed from default import to named import of minimatch.

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)
Minimatch changelog: https://github.com/isaacs/minimatch/blob/main/changelog.md

### Links
[//]: # (Related issues, references)
WRP-24433

### Comments

Enact-DCO-1.0-Signed-off-by: Daniel Stoian [daniel.stoian@lgepartner.com]
