### PR TITLE
WRR-4860: Remove deprecated util._extend() and use Object.assign()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The following is a curated list of changes in the Enact eslint plugin:
 
 ## [unreleased]
 
+* Fixed deprecation warning regarding nodejs.
 * Updated `minimatch` version to `^10.0.1`.
 * Updated the minimum version of Node to `^20.0.0 || >=22.0.0`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ The following is a curated list of changes in the Enact eslint plugin:
 
 ## [unreleased]
 
-* Fixed deprecation warning regarding nodejs.
+* Fixed a deprecation warning regarding nodejs.
 * Updated `minimatch` version to `^10.0.1`.
 * Updated the minimum version of Node to `^20.0.0 || >=22.0.0`.
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -70,7 +70,7 @@ Components.prototype.set = function(node, props) {
     return;
   }
   var id = this._getId(node);
-  this._list[id] = util._extend(this._list[id], props);
+  this._list[id] = Object.assign(this._list[id], props);
 };
 
 /**
@@ -614,7 +614,7 @@ function componentRule(rule, context) {
 
   // Update the provided rule instructions to add the component detection
   var ruleInstructions = rule(context, components, utils);
-  var updatedRuleInstructions = util._extend({}, ruleInstructions);
+  var updatedRuleInstructions = Object.assign({}, ruleInstructions);
   Object.keys(detectionInstructions).forEach(function(instruction) {
     updatedRuleInstructions[instruction] = function(node) {
       detectionInstructions[instruction](node);


### PR DESCRIPTION
### Checklist

* [x] I have read and understand the [contribution guide](http://enactjs.com/docs/developer-guide/contributing/)
* [x] A [CHANGELOG entry](http://enactjs.com/docs/developer-guide/contributing/changelogs/) is included
* [ ] At least one test case is included for this feature or bug fix
* [x] I have run automated CLI testing and it is passed
* [x] Documentation was added or is not needed
* [ ] This is an API breaking change

### Issue Resolved / Feature Added
[//]: # (Describe the issue resolved or feature added by this pull request)
When using node v22, DeprecationWarning occurred while `enact lint`
```shell
worker@taeyoung-hong-oebuild2:~/sandstone$ nvm use 22 && enact lint --strict
Now using node v22.9.0 (npm v10.8.3)
(node:13116) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
``` 
reference: https://nodejs.org/api/util.html#util_extendtarget-source



### Resolution
[//]: # (Does the code work as intended?)
[//]: # (What is the impact of this change and *why* was it made?)
Remove deprecated util._extend() and use Object.assign()

### Additional Considerations
[//]: # (How should the change be tested?)
[//]: # (Are there any outstanding questions?)
[//]: # (Were any side-effects caused by the change?)


### Links
[//]: # (Related issues, references)
WRR-4860

### Comments
Enact-DCO-1.0-Signed-off-by: Taeyoung Hong (taeyoung.hong@lge.com)